### PR TITLE
Update gen-users script to not rely on config file

### DIFF
--- a/bin/gen-users.rkt
+++ b/bin/gen-users.rkt
@@ -1,27 +1,36 @@
 #!/usr/bin/env racket
 #lang racket
-(require
-  (only-in "utils/config.rkt" grade-server-dir))
 
+;; Usage: ./gen-users.rkt raw-user-list [existing-users-file]
+;;
+;; Reads in a file of the form (listof (fullname email)) (given as the first command-line argument)
+;; and writes to stdout a new user.rktd file with a new user entry for each entry in the input. If an
+;; existing users file is given, those users are prepended to the output.
+
+;; Generates a (plaintext) password consisting of a lowercase letter followed by up to 6 digits
+(define (gen-password)
+  (string-append (string (integer->char (+ 97 (random 26)))) (number->string (random 1000000))))
 
 ;; gen-users
 ;; (listof (fullname email)) -> void
 ;; given a list of grader names and email addresses, generate an initial
 ;; users.rtkd. Every user has a default password of "password"
-(define (gen-users ls)
- (let ([users (with-input-from-file (build-path (grade-server-dir) "users.rktd") read)])
-   (with-output-to-file
-     (build-path (grade-server-dir) "users.rktd")
-     (thunk
-       (pretty-write (append (map (lambda (p)
-                        ;; "password"
-                  (let* ([pass "5f4dcc3b5aa765d61d8327deb882cf99"]
-                         [name (car p)]
-                         [email (cadr p)]
-                         [user (string->symbol (car (string-split email "@")))])
-                        `(,user (,pass ,name ,email "" "")))) ls)
-                             users)))
-     #:exists 'replace)))
+(define (gen-users existing-users ls)
+  (pretty-write
+   (append
+    existing-users
+    (for/list ([p ls])
+      (let* ([pass (gen-password)]
+             [name (car p)]
+             [email (cadr p)]
+             [user (string->symbol (car (string-split email "@")))])
+        `(,user ((plaintext ,pass) ,name ,email "" "")))))))
 
-(gen-users (with-input-from-file (vector-ref
-                                   (current-command-line-arguments) 1) read))
+(define existing-users
+  (if (> (vector-length (current-command-line-arguments)) 1)
+      (with-input-from-file (vector-ref (current-command-line-arguments) 1) read)
+      null))
+
+(gen-users existing-users
+           (with-input-from-file (vector-ref
+                                   (current-command-line-arguments) 0) read))


### PR DESCRIPTION
@LeifAndersen I updated this file so that it works now, and also doesn't rely on the config file - you can instead just specify the existing users.rktd as an optional cmd line argument. If you like it, you can merge this in; otherwise I can add it as a seprate tool.
